### PR TITLE
Fixed Debian dependancy issue, added libsdl2-dev dependancy 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ else
 ifeq ($(shell cat /etc/os-release | awk '{if (match ($$0, /debian/)) {print "true"; exit;}}'),true)
 	@echo "Debian"
 	@sudo apt-get update -y
-	@sudo apt-get install libopencv-dev libsdl2-2.0-0 libsdl2-image-dev -y
+	@sudo apt-get install libopencv-dev libsdl2-2.0-0 libsdl2-image-dev libsdl2-dev -y
 else ifeq ($(shell uname -a | awk '{if (match ($$0, /Darwin/)) print "true"}'),true)
 	@echo "Mac"
 	@brew install opencv sdl2


### PR DESCRIPTION
My Debian based distro wasn't detecting the SDL2 files with the Makefile.
Adding this dependancy should fix the issue for most.