### PR TITLE
Updated erosion function for different kernel sizes

### DIFF
--- a/4_cv_basics/6_morphology/src/morphology.cpp
+++ b/4_cv_basics/6_morphology/src/morphology.cpp
@@ -27,7 +27,7 @@ int kernel_sum(Mat image, int row, int col, int Kernel_size)
 {
 	if (Kernel_size % 2 != 1 || Kernel_size < 3)
 	{
-		std::cout << "Kernel size should be of odd and grater than or equal to 3";
+		std::cout << "Kernel size should be of odd and greater than or equal to 3";
 		return -1;
 	}
 
@@ -53,7 +53,7 @@ Mat erosion(Mat source_image, Mat output_image, int Kernel_size)
 	{
 		for (int j = 0; j < source_image.cols; j++)
 		{
-			if (kernel_sum(source_image, i, j, Kernel_size) != 255 * 9)
+			if (kernel_sum(source_image, i, j, Kernel_size) != 255 * (Kernel_size*Kernel_size))
 			{
 				output_image.at<u_char>(i, j) = saturate_cast<char>(0);
 			}


### PR DESCRIPTION
changed the erosion function in `4_cv_basics/6_morphology/src/morphology.cpp` to get correct output for different kernel sizes defined by user

1. 3x3 kernel in gradient operation
![Screenshot from 2024-02-24 22-08-21](https://github.com/SRA-VJTI/Pixels_Seminar/assets/72208314/c962efcd-f677-4589-b549-ab108f5127db)
2. 5x5 kernel in gradient operation
![Screenshot from 2024-02-24 22-07-55](https://github.com/SRA-VJTI/Pixels_Seminar/assets/72208314/064b32cf-7e0b-4187-b3ab-761c87326be9)

