### PR TITLE
Improve examples by explicitly using cv:: prefix for clarity

### DIFF
--- a/2_build_systems/2_build_systems.cpp
+++ b/2_build_systems/2_build_systems.cpp
@@ -23,25 +23,25 @@ SOFTWARE.
 */
 #include "2_build_systems.hpp"
 
-using namespace cv;
+
 using namespace std;
 
 int main(int argc, char** argv)
 {
     // Create a black image
-    Mat image = Mat::zeros( 400, 400, CV_8UC3 );
+    cv::Mat image = cv::Mat::zeros( 400, 400, CV_8UC3 );
 
     // Write some Text
-    putText(image, "Hello World :)", Point(15, 200),
-        FONT_HERSHEY_SIMPLEX, 2, Scalar(0, 255, 0), 3);
+    cv::putText(image, "Hello World :)", cv::Point(15, 200),
+        cv::FONT_HERSHEY_SIMPLEX, 2, cv::Scalar(0, 255, 0), 3);
 
-    imshow("Hello World", image);
+    cv::imshow("Hello World", image);
     
     //display an image from the $PROJECT_SOURCE_DIR/assets/images/b&w.PNG
-    Mat img = imread("PROJECT_SOURCE_DIR/assets/images/bcci.png", IMREAD_COLOR);
-    imshow("b&w", img);
+    cv::Mat img = cv::imread("PROJECT_SOURCE_DIR/assets/images/bcci.png", cv::IMREAD_COLOR);
+    cv::imshow("b&w", img);
 
     // Wait for a keystroke in the window
-    waitKey(0);
+    cv::waitKey(0);
     return 0;
 }

--- a/4_cv_basics/2_playing_with_images/0_accessing_pixels/main.cpp
+++ b/4_cv_basics/2_playing_with_images/0_accessing_pixels/main.cpp
@@ -26,57 +26,55 @@ SOFTWARE.
 #include <opencv2/imgproc.hpp>
 
 using namespace std;
-using namespace cv;
 
 //declaring functions for different operations
-Mat black_out_rows(Mat img, int height, int width);
-Mat change_blue(Mat img, int height, int width);
+cv::Mat black_out_rows(cv::Mat img, int height, int width);
+cv::Mat change_blue(cv::Mat img, int height, int width);
 
-int main()
-{
-    //reading the image and converting it into cv::Mat formatt
-    Mat img = imread("./assets/dog.jpeg");
-    Mat img2, img3;
+int main() {
+    //reading the image and converting it into cv::Mat format
+    cv::Mat img = cv::imread("./assets/dog.jpeg");
+    cv::Mat img2, img3;
+    
     //obtaining the dimensions of the image
     int width = img.size().width;
     int height = img.size().height;
     int choice;
+    
     cout << "Width of the image: " << width << endl;
     cout << "Height of the image: " << height << endl;
-
+    
     cout << "You have a choice to make - 0 or 1. What will it be? ";
     cin >> choice;
-    if (choice == 0)
-    {
+    
+    if (choice == 0) {
         //making alternate rows of pixels of the image black
         img2 = black_out_rows(img, height, width);
         //displaying the image on the screen. The image will be displayed until any key is pressed
-        imshow("window", img2);
-        waitKey(0);
-    }
-    else if (choice == 1)
-    {
-        // changing only one channel of the image, in this case, blue
+        cv::imshow("window", img2);
+        cv::waitKey(0);
+    } else if (choice == 1) {
+        //changing only one channel of the image, in this case, blue
         img3 = change_blue(img, height, width);
-        imshow("processed image", img3);
-        waitKey(0);
+        cv::imshow("processed image", img3);
+        cv::waitKey(0);
     }
-
+    
     return 0;
 }
 
 //defining the functions
 
 //making alternate rows of pixels of the image black
-Mat black_out_rows(Mat img, int height, int width){
-    for (int i=0; i<height; i++){
-        for (int j=0; j<width; j++){
-            if(i%2==0){
+cv::Mat black_out_rows(cv::Mat img, int height, int width) {
+    for (int i = 0; i < height; i++) {
+        for (int j = 0; j < width; j++) {
+            if (i % 2 == 0) {
                 //this statement accesses the individual pixel values of the image
                 //and sets the color values of each channel of every coordinate to 0
-                img.at<Vec3b>(i,j)[0]=0;
-                img.at<Vec3b>(i,j)[1]=0;
-                img.at<Vec3b>(i,j)[2]=0;
+                img.at<cv::Vec3b>(i, j)[0] = 0;
+                img.at<cv::Vec3b>(i, j)[1] = 0;
+                img.at<cv::Vec3b>(i, j)[2] = 0;
             }
         }
     }
@@ -84,13 +82,13 @@ Mat black_out_rows(Mat img, int height, int width){
 }
 
 //changing only one channel of the image, in this case, blue
-Mat change_blue(Mat img, int height, int width){
-    for (int i=0; i<height; i++){
-        for (int j=0; j<width; j++){
-            if(i%2==0){
+cv::Mat change_blue(cv::Mat img, int height, int width) {
+    for (int i = 0; i < height; i++) {
+        for (int j = 0; j < width; j++) {
+            if (i % 2 == 0) {
                 //this statement accesses the individual pixel values of the image
-                //and sets the color values of each channel of every coordinate to 0
-                img.at<Vec3b>(i,j)[0]=255;
+                //and sets the color values of each channel of every coordinate to 255 in the blue channel
+                img.at<cv::Vec3b>(i, j)[0] = 255;
             }
         }
     }

--- a/4_cv_basics/2_playing_with_images/1_drawing_on_images/main.cpp
+++ b/4_cv_basics/2_playing_with_images/1_drawing_on_images/main.cpp
@@ -27,43 +27,40 @@ SOFTWARE.
 #include <opencv2/imgproc.hpp>
 
 using namespace std;
-using namespace cv;
 
 int main(){
 
     //creating a blank Mat image
     //img(height, width, cv 8-bit 3 channels, BGR)
-    Mat img(480, 720, CV_8UC3, Scalar(0, 0, 0));
+    cv::Mat img(480, 720, CV_8UC3, cv::Scalar(0, 0, 0));
     
-   
     //drawing horizontal line on image 
     for(int j = 100,i = 200;j <= 620;j++){
-        img.at<Vec3b>(i,j)[0] = 255;
-        img.at<Vec3b>(i,j)[1] = 255;
-        img.at<Vec3b>(i,j)[2] = 255;
+        img.at<cv::Vec3b>(i,j)[0] = 255;
+        img.at<cv::Vec3b>(i,j)[1] = 255;
+        img.at<cv::Vec3b>(i,j)[2] = 255;
     } 
 
     //draing vertical line on image 
     for(int i = 80,j = 300;i <= 400;i++){
-        img.at<Vec3b>(i,j)[0] = 255;
-        img.at<Vec3b>(i,j)[1] = 255;
-        img.at<Vec3b>(i,j)[2] = 255;        
+        img.at<cv::Vec3b>(i,j)[0] = 255;
+        img.at<cv::Vec3b>(i,j)[1] = 255;
+        img.at<cv::Vec3b>(i,j)[2] = 255;        
     }
 
     //drawing an inclined line at 45 degree
     for(int i = 100;i <= 300;i++){
         for(int j = 100;j <= 300;j++){
             if(i == j){
-                img.at<Vec3b>(i,j)[0] = 255;
-                img.at<Vec3b>(i,j)[1] = 255;
-                img.at<Vec3b>(i,j)[2] = 255; 
+                img.at<cv::Vec3b>(i,j)[0] = 255;
+                img.at<cv::Vec3b>(i,j)[1] = 255;
+                img.at<cv::Vec3b>(i,j)[2] = 255; 
             }
             else continue;
         }
     }
-    imshow("Drawing", img);
-    waitKey(0);
+    cv::imshow("Drawing", img);
+    cv::waitKey(0);
 
     return 0;
 }
-

--- a/4_cv_basics/2_playing_with_images/2_image_cropping/main.cpp
+++ b/4_cv_basics/2_playing_with_images/2_image_cropping/main.cpp
@@ -25,47 +25,46 @@ SOFTWARE.
 #include <opencv2/core.hpp>
  
 using namespace std;
-using namespace cv;
- 
+
 int main(){
     //reading an image and converting to cv::Mat format
-    Mat img = imread("./assets/dog.jpeg", IMREAD_GRAYSCALE);
-    Mat img4;
-    Vec3b* ptr;
- 
+    cv::Mat img = cv::imread("./assets/dog.jpeg", cv::IMREAD_GRAYSCALE);
+    cv::Mat img4;
+    cv::Vec3b* ptr;
+
     //obtaining the dimensions of the image
     int width = img.size().width;
     int height = img.size().height;
     cout << "Width of the image: " << width << endl;
     cout << "Height of the image: " << height << endl;
- 
-    Mat img3 = Mat::zeros(Size(height/2, width/2), CV_8UC1);
- 
+
+    cv::Mat img3 = cv::Mat::zeros(cv::Size(height/2, width/2), CV_8UC1);
+
     //image compression
     //resizing an image-this essentially removes every alternate pixel rows
-    resize(img, img4, Size(width/2, height/2));
- 
+    cv::resize(img, img4, cv::Size(width/2, height/2));
+
     //cropping an image
     // The general syntax for cropping an image is :
     // img(Range(start_row, end_row), Range(start_column, end_column));
     // The following is using OpenCV Mat container's inbuilt slicing functionality
-    Mat img2 = img(Range(0, width/2), Range(0, height/2));
- 
+    cv::Mat img2 = img(cv::Range(0, width/2), cv::Range(0, height/2));
+
     // The following implementation is using for loop to demonstrate pointer arithmetic
     for(int r = 0; r<height/2; r++)
     {
         for(int c = 0; c<width/2; c++)
         {
-            img3.at<uchar>(c,r)=img.at<uchar>(c,r);
+            img3.at<uchar>(c,r) = img.at<uchar>(c,r);
         }
     }
- 
+
     //displaying the images
-    imshow("window", img);
-    imshow("resized image", img4);
-    imshow("cropped image", img2);
-    imshow("cropped image retake", img3);
-    waitKey(0);
- 
+    cv::imshow("window", img);
+    cv::imshow("resized image", img4);
+    cv::imshow("cropped image", img2);
+    cv::imshow("cropped image retake", img3);
+    cv::waitKey(0);
+
     return 0;
 }

--- a/4_cv_basics/2_playing_with_images/3_image_translation/main.cpp
+++ b/4_cv_basics/2_playing_with_images/3_image_translation/main.cpp
@@ -24,11 +24,10 @@ SOFTWARE.
 #include <opencv2/imgproc.hpp>
 
 using namespace std;
-using namespace cv;
 
 int main(){
     // reading image and storing it in Mat format
-    Mat image = imread("./assets/dog.jpeg", IMREAD_GRAYSCALE);
+    cv::Mat image = cv::imread("./assets/dog.jpeg", cv::IMREAD_GRAYSCALE);
 
     // storing the dimensions of the image
     int height = image.cols;
@@ -38,32 +37,32 @@ int main(){
     float tx = float(width) / 4;
     float ty = float(height) / 4;
 
-    Mat img2 = Mat::zeros(Size(height, width), CV_8UC1);
+    cv::Mat img2 = cv::Mat::zeros(cv::Size(height, width), CV_8UC1);
     
     // create the translation matrix using tx and ty
     float warp_values[] = { 1.0, 0.0, tx, 0.0, 1.0, ty };
-    Mat translation_matrix = Mat(2, 3, CV_32F, warp_values);
-    cout<<translation_matrix;
+    cv::Mat translation_matrix = cv::Mat(2, 3, CV_32F, warp_values);
+    cout << translation_matrix;
 
     // save the resulting image in translated_image matrix
-    Mat translated_image;
+    cv::Mat translated_image;
 
     // apply affine transformation to the original image using the translation matrix
-    warpAffine(image, translated_image, translation_matrix, image.size());
+    cv::warpAffine(image, translated_image, translation_matrix, image.size());
 
-    for(int r = 0; r<height-ty; r++)
+    for(int r = 0; r < height - ty; r++)
     {
-        for(int c = 0; c<width-tx; c++)
+        for(int c = 0; c < width - tx; c++)
         {
-            img2.at<uchar>(c,r)=image.at<uchar>(c+tx, r+ty);
+            img2.at<uchar>(c, r) = image.at<uchar>(c + tx, r + ty);
         }
     }
 
-    //display the original and the Translated images
-    imshow("Translated image", translated_image);
-    imshow("Translated Image Version", img2);
-    imshow("Original image", image);
-    waitKey(0);
+    // display the original and the Translated images
+    cv::imshow("Translated image", translated_image);
+    cv::imshow("Translated Image Version", img2);
+    cv::imshow("Original image", image);
+    cv::waitKey(0);
 
     return 0;
 }

--- a/4_cv_basics/2_playing_with_images/4_image_rotation/main.cpp
+++ b/4_cv_basics/2_playing_with_images/4_image_rotation/main.cpp
@@ -24,35 +24,34 @@ SOFTWARE.
 #include <opencv2/imgproc.hpp>
 
 using namespace std;
-using namespace cv;
 
-// rotate function returning mat object with parametres imagefile and angle
-Mat rotate(Mat src, double angle)
+// rotate function returning mat object with parameters imagefile and angle
+cv::Mat rotate(cv::Mat src, double angle)
 {
     // Mat object for output image file
-    Mat dst;
+    cv::Mat dst;
     // defining point with respect to which to rotate
-    Point2f pt(src.cols/2., src.rows/2.);
+    cv::Point2f pt(src.cols/2., src.rows/2.);
     // Mat object for storing after rotation
-    Mat r = getRotationMatrix2D(pt, angle, 1.0);
-    // apply an affine transforation to image.
-    warpAffine(src, dst, r, Size(src.cols, src.rows));
+    cv::Mat r = cv::getRotationMatrix2D(pt, angle, 1.0);
+    // apply an affine transformation to image.
+    cv::warpAffine(src, dst, r, cv::Size(src.cols, src.rows));
     //returning Mat object for output image file
     return dst;
 }
 
 int main(){
     // converting the image into Mat format
-    Mat img = imread("./assets/dog.jpeg");
-    Mat img2;
+    cv::Mat img = cv::imread("./assets/dog.jpeg");
+    cv::Mat img2;
     // obtaining the image dimensions
     int height=img.size().height;
     int width=img.size().width;
 
     img2 = rotate(img, 90);
     // displaying these images
-    imshow("rotated image", img2);
-    waitKey(0);
+    cv::imshow("rotated image", img2);
+    cv::waitKey(0);
     
     return 0;
 }

--- a/4_cv_basics/4_convolutions_filtering/src/convolution.cpp
+++ b/4_cv_basics/4_convolutions_filtering/src/convolution.cpp
@@ -29,16 +29,15 @@ SOFTWARE.
     Namespace is a declarative region that provides a scope to the identifiers (the names of types, functions, variables, etc) inside it. 
 */
 using namespace std;
-using namespace cv;
 
 /// @brief : Convolution will help apply different kernels to your images yielding different results
 /// @param   Original_image
 /// @param   kernel
 /// @return : An Output Image with the kernel applied
-Mat convolve(Mat original_image, Mat kernel){
+cv::Mat convolve(cv::Mat original_image, cv::Mat kernel){
     
-    Mat kernel_inv{kernel.size(), kernel.type()}, temp_kernel{kernel.size(), kernel.type()}, image_pad;
-    Mat resultant_image{original_image.size(), original_image.type()};
+    cv::Mat kernel_inv{kernel.size(), kernel.type()}, temp_kernel{kernel.size(), kernel.type()}, image_pad;
+    cv::Mat resultant_image{original_image.size(), original_image.type()};
     
     // Using For Loops
     // for(int i = 0 ; i < kernel.rows ; i++ ){ cout<<"k"<<endl; kernel_inv.row(i) = kernel.row(kernel.rows - i - 1).clone(); }
@@ -52,7 +51,7 @@ Mat convolve(Mat original_image, Mat kernel){
     // cout<<original_image.channels()<<endl;
 
     // Adding Padding to the Image 
-    copyMakeBorder( original_image, image_pad, 1, 1, 1, 1, BORDER_REPLICATE, Scalar(0)); 
+    cv::copyMakeBorder(original_image, image_pad, 1, 1, 1, 1, cv::BORDER_REPLICATE, cv::Scalar(0)); 
 
     for (int i = 1; i < image_pad.rows - 1; i++) 
     {   
@@ -69,17 +68,15 @@ Mat convolve(Mat original_image, Mat kernel){
                         int y = i - 1 + k;  
 
                         if ((x >= 0 && x < image_pad.cols) && (y >= 0 && y < image_pad.rows)){
-                            tmp += (double)image_pad.at<Vec3b>(y, x).val[ch] * (double)kernel.at<double>(k, l);
+                            tmp += (double)image_pad.at<cv::Vec3b>(y, x).val[ch] * (double)kernel.at<double>(k, l);
                         }
                     }
                 }
 
-                resultant_image.at<Vec3b>(i-1, j-1).val[ch] = saturate_cast<uchar>(tmp);        // Why Unsigned? 
+                resultant_image.at<cv::Vec3b>(i-1, j-1).val[ch] = cv::saturate_cast<uchar>(tmp);        // Why Unsigned? 
             }
         }
     }
 
     return resultant_image;
-
 }
-

--- a/4_cv_basics/5_masking/main.cpp
+++ b/4_cv_basics/5_masking/main.cpp
@@ -23,28 +23,26 @@ SOFTWARE.
 */
 #include <opencv4/opencv2/opencv.hpp>
 #include <iostream>
-using namespace cv;
 using namespace std;
 
-
-Mat masking(Mat image)
+cv::Mat masking(cv::Mat image)
 {
-   Vec3b grey = Vec3b(230,230,230); //defining masks for the colours which you do not need in the image
-   Vec3b white = Vec3b(255,255,255); //so here we want to mask grey and white colours
+   cv::Vec3b grey = cv::Vec3b(230,230,230); //defining masks for the colours which you do not need in the image
+   cv::Vec3b white = cv::Vec3b(255,255,255); //so here we want to mask grey and white colours
    
    int height = image.rows; //taking the height and width of the input 'image'
    int width = image.cols;
 
-   Mat transparentImg{image.size(), image.type()}; //creates a new transparent empty image
+   cv::Mat transparentImg{image.size(), image.type()}; //creates a new transparent empty image
 
    for(int i = 0; i < height; i++)
    {
       for(int j = 0; j < width; j++)
       {
-         Vec3b x = image.at<Vec3b>(i, j); //getting the pixel rgb values
+         cv::Vec3b x = image.at<cv::Vec3b>(i, j); //getting the pixel rgb values
          if(grey != x && white != x)
          {
-            transparentImg.at<Vec3b>(i,j)=x; //write to the new image all other colours except the one's to be ignored
+            transparentImg.at<cv::Vec3b>(i,j)=x; //write to the new image all other colours except the one's to be ignored
          }
       }
    }
@@ -53,14 +51,14 @@ Mat masking(Mat image)
 
 int main() 
 {
-   Mat image; //taking an image matrix
-   image = imread("assets/nike.png"); //loading an image
+   cv::Mat image; //taking an image matrix
+   image = cv::imread("assets/nike.png"); //loading an image
    
-   Mat new_img = masking(image);
-   imwrite("assets/bg_free.png", new_img);
-   imshow("center",new_img);
-   waitKey(0);
-   destroyAllWindows();
-	   
+   cv::Mat new_img = masking(image);
+   cv::imwrite("assets/bg_free.png", new_img);
+   cv::imshow("center",new_img);
+   cv::waitKey(0);
+   cv::destroyAllWindows();
+   
    return 0;
 }

--- a/4_cv_basics/6_morphology/1_erosion/main.cpp
+++ b/4_cv_basics/6_morphology/1_erosion/main.cpp
@@ -29,42 +29,38 @@ SOFTWARE.
 
 #include "../include/morphology.hpp"
 
-using namespace cv;
 using namespace std;
 
 int main(int argc, char **argv)
 {
-	if ( argc != 2 )	
+    if (argc != 2)
     {
-        std::cout <<"usage: ./output <Image_Path>\n";
+        std::cout << "usage: ./output <Image_Path>\n";
         return -1;
     }
-
-	// Reading the Image
-	Mat source_image = imread(argv[1], IMREAD_GRAYSCALE);
-	
-	// Check if the image is created successfully or not
-	if (!source_image.data)
-	{
-		cout << "Could not open or find the image\n";
-		return 0;
-	}
-
-	// creating container for output image according to size and type of source image
-	Mat output_image{source_image.size(), source_image.type()};
-	
-	// Applying erosion on source image
-	int kernel_size = 3;
-	output_image = erosion(source_image, output_image, kernel_size);
-
-	// Displaying both source and output image
-	namedWindow("source", WINDOW_NORMAL);
-	imshow("source", source_image);
-
-	namedWindow("output", WINDOW_NORMAL);
-	imshow("output", output_image);
-
-	waitKey();
-
-	return 0;
+    // Reading the Image
+    cv::Mat source_image = cv::imread(argv[1], cv::IMREAD_GRAYSCALE);
+    
+    // Check if the image is created successfully or not
+    if (!source_image.data)
+    {
+        cout << "Could not open or find the image\n";
+        return 0;
+    }
+    
+    // creating container for output image according to size and type of source image
+    cv::Mat output_image{source_image.size(), source_image.type()};
+    
+    // Applying erosion on source image
+    int kernel_size = 3;
+    output_image = erosion(source_image, output_image, kernel_size);
+    
+    // Displaying both source and output image
+    cv::namedWindow("source", cv::WINDOW_NORMAL);
+    cv::imshow("source", source_image);
+    cv::namedWindow("output", cv::WINDOW_NORMAL);
+    cv::imshow("output", output_image);
+    cv::waitKey();
+    
+    return 0;
 }

--- a/4_cv_basics/6_morphology/2_dilation/main.cpp
+++ b/4_cv_basics/6_morphology/2_dilation/main.cpp
@@ -29,42 +29,38 @@ SOFTWARE.
 
 #include "../include/morphology.hpp"
 
-using namespace cv;
 using namespace std;
 
 int main(int argc, char **argv)
 {
-	if ( argc != 2 )	
+    if (argc != 2)
     {
-        std::cout <<"usage: ./output <Image_Path>\n";
+        std::cout << "usage: ./output <Image_Path>\n";
         return -1;
     }
-
-	// Reading the Image
-	Mat source_image = imread(argv[1], IMREAD_GRAYSCALE);
-
-	// Check if the image is created successfully or not
-	if (!source_image.data)
-	{
-		std::cout << "Could not open or find the image\n";
-		return 0;
-	}
-
-	// creating container for output image according to size and type of source image
-	Mat output_image{source_image.size(), source_image.type()};
-
-	// Applying dilation on source image
-	int kernel_size = 3;
-	output_image = dilation(source_image, output_image, kernel_size);
-
-	// Displaying both source and output image
-	namedWindow("source", WINDOW_NORMAL);
-	imshow("source", source_image);
-
-	namedWindow("output", WINDOW_NORMAL);
-	imshow("output", output_image);
-
-	waitKey();
-
-	return 0;
+    // Reading the Image
+    cv::Mat source_image = cv::imread(argv[1], cv::IMREAD_GRAYSCALE);
+    
+    // Check if the image is created successfully or not
+    if (!source_image.data)
+    {
+        std::cout << "Could not open or find the image\n";
+        return 0;
+    }
+    
+    // creating container for output image according to size and type of source image
+    cv::Mat output_image{source_image.size(), source_image.type()};
+    
+    // Applying dilation on source image
+    int kernel_size = 3;
+    output_image = dilation(source_image, output_image, kernel_size);
+    
+    // Displaying both source and output image
+    cv::namedWindow("source", cv::WINDOW_NORMAL);
+    cv::imshow("source", source_image);
+    cv::namedWindow("output", cv::WINDOW_NORMAL);
+    cv::imshow("output", output_image);
+    cv::waitKey();
+    
+    return 0;
 }

--- a/4_cv_basics/6_morphology/3_opening/main.cpp
+++ b/4_cv_basics/6_morphology/3_opening/main.cpp
@@ -29,46 +29,43 @@ SOFTWARE.
 
 #include "../include/morphology.hpp"
 
-using namespace cv;
 using namespace std;
 
 int main(int argc, char** argv)
 {
-	if ( argc != 2 )	
+    if (argc != 2)
     {
-        std::cout <<"usage: ./output <Image_Path>\n";
+        std::cout << "usage: ./output <Image_Path>\n";
         return -1;
     }
-
-	// Reading the Image
-	Mat source_image = imread(argv[1], IMREAD_GRAYSCALE);
-
-	// Check if the image is created successfully or not
-	if (!source_image.data) {
-		std::cout << "Could not open or find the image\n";
-		return 0;
-	}
-
-	// creating container for output image according to size and type of source image
-	Mat temp1{source_image.size(), source_image.type()};
-    Mat output_image{source_image.size(), source_image.type()};
-
-	//Applying erosion on source image
-	int kernel_size_erosion = 3;
-	temp1 = erosion(source_image, temp1,kernel_size_erosion);
-
+    // Reading the Image
+    cv::Mat source_image = cv::imread(argv[1], cv::IMREAD_GRAYSCALE);
+    
+    // Check if the image is created successfully or not
+    if (!source_image.data) 
+    {
+        std::cout << "Could not open or find the image\n";
+        return 0;
+    }
+    
+    // creating container for output image according to size and type of source image
+    cv::Mat temp1{source_image.size(), source_image.type()};
+    cv::Mat output_image{source_image.size(), source_image.type()};
+    
+    //Applying erosion on source image
+    int kernel_size_erosion = 3;
+    temp1 = erosion(source_image, temp1, kernel_size_erosion);
+    
     // Applying dilation on erroded image
-	int kernel_size_dilation = 3;
-	output_image = dilation(temp1, output_image,kernel_size_dilation);
-
-	//Displaying both source and output image
-	namedWindow("source", WINDOW_NORMAL);
-	imshow("source", source_image);
-	
-	namedWindow("output", WINDOW_NORMAL);
-	imshow("output", output_image);
-
-	waitKey();
-
-	return 0;
+    int kernel_size_dilation = 3;
+    output_image = dilation(temp1, output_image, kernel_size_dilation);
+    
+    //Displaying both source and output image
+    cv::namedWindow("source", cv::WINDOW_NORMAL);
+    cv::imshow("source", source_image);
+    cv::namedWindow("output", cv::WINDOW_NORMAL);
+    cv::imshow("output", output_image);
+    cv::waitKey();
+    
+    return 0;
 }

--- a/4_cv_basics/6_morphology/4_closing/main.cpp
+++ b/4_cv_basics/6_morphology/4_closing/main.cpp
@@ -29,46 +29,43 @@ SOFTWARE.
 
 #include "../include/morphology.hpp"
 
-using namespace cv;
 using namespace std;
 
 int main(int argc, char **argv)
 {
-	if ( argc != 2 )	
-    {
-        std::cout <<"usage: ./output <Image_Path>\n";
-        return -1;
-    }
-
-	// Reading the Image
-	Mat source_image = imread(argv[1], IMREAD_GRAYSCALE);
-
-	// Check if the image is created successfully or not
-	if (!source_image.data) {
-		std::cout << "Could not open or find the image\n";
-		return 0;
-	}
-
-	// creating container for output image according to size and type of source image
-	Mat temp1{source_image.size(), source_image.type()};
-    Mat output_image{source_image.size(), source_image.type()};
-
-	//Applying dilation on source image
-	int kernel_size_dilation = 3;
-	temp1 = dilation(source_image, temp1,kernel_size_dilation);
-
-    // Applying erosion on dilated image
-	int kernel_size_erosion = 3;
-	output_image = erosion(temp1, output_image,kernel_size_erosion);
-
-	//Displaying both source and output image
-	namedWindow("source", WINDOW_NORMAL);
-	imshow("source", source_image);
-	
-	namedWindow("output", WINDOW_NORMAL);
-	imshow("output", output_image);
-
-	waitKey();
-
-	return 0;
+   if (argc != 2)
+   {
+       std::cout << "usage: ./output <Image_Path>\n";
+       return -1;
+   }
+   // Reading the Image
+   cv::Mat source_image = cv::imread(argv[1], cv::IMREAD_GRAYSCALE);
+   
+   // Check if the image is created successfully or not
+   if (!source_image.data) 
+   {
+       std::cout << "Could not open or find the image\n";
+       return 0;
+   }
+   
+   // creating container for output image according to size and type of source image
+   cv::Mat temp1{source_image.size(), source_image.type()};
+   cv::Mat output_image{source_image.size(), source_image.type()};
+   
+   //Applying dilation on source image
+   int kernel_size_dilation = 3;
+   temp1 = dilation(source_image, temp1, kernel_size_dilation);
+   
+   // Applying erosion on dilated image
+   int kernel_size_erosion = 3;
+   output_image = erosion(temp1, output_image, kernel_size_erosion);
+   
+   //Displaying both source and output image
+   cv::namedWindow("source", cv::WINDOW_NORMAL);
+   cv::imshow("source", source_image);
+   cv::namedWindow("output", cv::WINDOW_NORMAL);
+   cv::imshow("output", output_image);
+   cv::waitKey();
+   
+   return 0;
 }

--- a/4_cv_basics/6_morphology/5_gradient/main.cpp
+++ b/4_cv_basics/6_morphology/5_gradient/main.cpp
@@ -29,51 +29,48 @@ SOFTWARE.
 
 #include "../include/morphology.hpp"
 
-using namespace cv;
 using namespace std;
 
 int main(int argc, char **argv)
 {
-	if (argc != 2)
-	{
-		std::cout << "usage: ./output <Image_Path>\n";
-		return -1;
-	}
+    if (argc != 2)
+    {
+        std::cout << "usage: ./output <Image_Path>\n";
+        return -1;
+    }
 
-	// Reading the Image
-	Mat source_image = imread(argv[1], IMREAD_GRAYSCALE);
+    // Reading the Image
+    cv::Mat source_image = cv::imread(argv[1], cv::IMREAD_GRAYSCALE);
 
-	// Check if the image is created successfully or not
-	if (!source_image.data)
-	{
-		std::cout << "Could not open or find the image\n";
-		return 0;
-	}
+    // Check if the image is created successfully or not
+    if (!source_image.data)
+    {
+        std::cout << "Could not open or find the image\n";
+        return 0;
+    }
 
-	// creating container for output image according to size and type of source image
-	Mat erod{source_image.size(), source_image.type()};
-	Mat dill{source_image.size(), source_image.type()};
-    Mat gradient{source_image.size(), source_image.type()};
+    // Creating container for output image according to size and type of source image
+    cv::Mat erod{source_image.size(), source_image.type()};
+    cv::Mat dill{source_image.size(), source_image.type()};
+    cv::Mat gradient{source_image.size(), source_image.type()};
 
-	// Applying erosion on source image
-	int kernel_size_erosion = 3;
-	erod = erosion(source_image, erod, kernel_size_erosion);
+    // Applying erosion on source image
+    int kernel_size_erosion = 3;
+    erod = erosion(source_image, erod, kernel_size_erosion);
 
-	// Applying dilation on source image
-	int kernel_size_dilation = 3;
-	dill = dilation(source_image, dill, kernel_size_dilation);
+    // Applying dilation on source image
+    int kernel_size_dilation = 3;
+    dill = dilation(source_image, dill, kernel_size_dilation);
 
-	// Taking difference of erroded and dilated image to get gradient
-	gradient = difference(dill, erod, gradient);
+    // Taking difference of eroded and dilated image to get gradient
+    gradient = difference(dill, erod, gradient);
 
-	//Displaying both source and output image
-	namedWindow("source", WINDOW_NORMAL);
-	imshow("source", source_image);
-	
-	namedWindow("gradient", WINDOW_NORMAL);
-	imshow("gradient", gradient);
+    // Displaying both source and output image
+    cv::namedWindow("source", cv::WINDOW_NORMAL);
+    cv::imshow("source", source_image);
+    cv::namedWindow("gradient", cv::WINDOW_NORMAL);
+    cv::imshow("gradient", gradient);
+    cv::waitKey();
 
-	waitKey();
-
-	return 0;
+    return 0;
 }

--- a/4_cv_basics/6_morphology/include/morphology.hpp
+++ b/4_cv_basics/6_morphology/include/morphology.hpp
@@ -27,8 +27,6 @@ SOFTWARE.
 #include <opencv2/core.hpp>
 #include <iostream>
 
-using namespace cv;
-
 /*
 / @brief finds sum of elements in a kernel about given co-ordinate(y, x)
 / @param Mat image
@@ -37,7 +35,7 @@ using namespace cv;
 / @param Kernel size
 / @return sum
 */
-int kernel_sum(Mat image, int row, int col, int Kernel_size);
+int kernel_sum(cv::Mat image, int row, int col, int Kernel_size);
 
 /*
 / @brief performs erosion on source image and stores it in output image
@@ -46,7 +44,7 @@ int kernel_sum(Mat image, int row, int col, int Kernel_size);
 / @param int Kernel size
 / @return output_image after erosion
 */
-Mat erosion(Mat source_image, Mat output_image, int Kernel_size);
+cv::Mat erosion(cv::Mat source_image, cv::Mat output_image, int Kernel_size);
 
 /*
 / @brief performs dilation on source image and stores it in output image
@@ -55,7 +53,7 @@ Mat erosion(Mat source_image, Mat output_image, int Kernel_size);
 / @param kernel size
 / @return output_image after erosion
 */
-Mat dilation(Mat source_image, Mat output_image, int kernel_size);
+cv::Mat dilation(cv::Mat source_image, cv::Mat output_image, int kernel_size);
 
 /*
 / @brief Gives difference between two given arrays
@@ -64,6 +62,6 @@ Mat dilation(Mat source_image, Mat output_image, int kernel_size);
 / @param output container to store output image
 / @return output image
 */
-Mat difference(Mat img_1, Mat img_2, Mat output);
+cv::Mat difference(cv::Mat img_1, cv::Mat img_2, cv::Mat output);
 
 #endif // !HELPER_HPP

--- a/4_cv_basics/6_morphology/src/morphology.cpp
+++ b/4_cv_basics/6_morphology/src/morphology.cpp
@@ -23,7 +23,7 @@ SOFTWARE.
 */
 #include "../include/morphology.hpp"
 
-int kernel_sum(Mat image, int row, int col, int Kernel_size)
+int kernel_sum(cv::Mat image, int row, int col, int Kernel_size)
 {
 	if (Kernel_size % 2 != 1 || Kernel_size < 3)
 	{
@@ -47,7 +47,7 @@ int kernel_sum(Mat image, int row, int col, int Kernel_size)
 	return sum;
 }
 
-Mat erosion(Mat source_image, Mat output_image, int Kernel_size)
+cv::Mat erosion(cv::Mat source_image, cv::Mat output_image, int Kernel_size)
 {
 	for (int i = 0; i < source_image.rows; i++)
 	{
@@ -55,11 +55,11 @@ Mat erosion(Mat source_image, Mat output_image, int Kernel_size)
 		{
 			if (kernel_sum(source_image, i, j, Kernel_size) != 255 * (Kernel_size*Kernel_size))
 			{
-				output_image.at<u_char>(i, j) = saturate_cast<char>(0);
+				output_image.at<u_char>(i, j) = cv::saturate_cast<char>(0);
 			}
 			else
 			{
-				output_image.at<u_char>(i, j) = saturate_cast<char>(255);
+				output_image.at<u_char>(i, j) = cv::saturate_cast<char>(255);
 			}
 		}
 	}
@@ -67,7 +67,7 @@ Mat erosion(Mat source_image, Mat output_image, int Kernel_size)
 	return output_image;
 }
 
-Mat dilation(Mat source_image, Mat output_image, int kernel_size)
+cv::Mat dilation(cv::Mat source_image, cv::Mat output_image, int kernel_size)
 {
 	for (int i = 0; i < source_image.rows; i++)
 	{
@@ -75,11 +75,11 @@ Mat dilation(Mat source_image, Mat output_image, int kernel_size)
 		{
 			if (kernel_sum(source_image, i, j, kernel_size) > 0)
 			{
-				output_image.at<u_char>(i, j) = saturate_cast<char>(255);
+				output_image.at<u_char>(i, j) = cv::saturate_cast<char>(255);
 			}
 			else
 			{
-				output_image.at<u_char>(i, j) = saturate_cast<char>(0);
+				output_image.at<u_char>(i, j) = cv::saturate_cast<char>(0);
 			}
 		}
 	}
@@ -87,7 +87,7 @@ Mat dilation(Mat source_image, Mat output_image, int kernel_size)
 	return output_image;
 }
 
-Mat difference(Mat img_1, Mat img_2, Mat output)
+cv::Mat difference(cv::Mat img_1, cv::Mat img_2, cv::Mat output)
 {
 	if (img_1.size() != img_2.size())
 	{
@@ -97,7 +97,7 @@ Mat difference(Mat img_1, Mat img_2, Mat output)
 	{
 		for (int j = 0; j < img_1.cols; j++)
 		{
-			output.at<u_char>(i, j) = saturate_cast<char>((abs)((int)img_1.at<u_char>(i, j) - (int)img_2.at<u_char>(i, j)));
+			output.at<u_char>(i, j) = cv::saturate_cast<char>((abs)((int)img_1.at<u_char>(i, j) - (int)img_2.at<u_char>(i, j)));
 		}
 	}
 	return output;

--- a/4_cv_basics/7_opencv_overview/1_read_display_image/main.cpp
+++ b/4_cv_basics/7_opencv_overview/1_read_display_image/main.cpp
@@ -23,13 +23,12 @@ SOFTWARE.
 */
 #include <iostream>
 #include <opencv2/opencv.hpp>
-using namespace cv;
 using namespace std;
 
 int main()
 {
-    Mat image;
-    image = imread("./assets/images/purple_night.jpg");
+    cv::Mat image;
+    image = cv::imread("./assets/images/purple_night.jpg");
     if (!image.data)
     {
         cout << "Image not found" << endl;
@@ -42,9 +41,9 @@ int main()
     // x[1] - width of the image (number of columns)
     cout << x[0] << ',' << x[1] << endl;
     cout << image.channels() << endl;
-    namedWindow("Display Image");
-    imshow("Display Image", image);
-    waitKey(0);
+    cv::namedWindow("Display Image");
+    cv::imshow("Display Image", image);
+    cv::waitKey(0);
 
     return 0;
 }

--- a/4_cv_basics/7_opencv_overview/2_grayscale/main.cpp
+++ b/4_cv_basics/7_opencv_overview/2_grayscale/main.cpp
@@ -23,25 +23,24 @@ SOFTWARE.
 */
 #include <iostream>
 #include <opencv2/opencv.hpp>
-using namespace cv;
 using namespace std;
 
 int main()
 {
-    Mat image;
+    cv::Mat image;
 
     // Reading image
-    image = imread("./assets/images/purple_night.jpg");
+    image = cv::imread("./assets/images/purple_night.jpg");
     if (!image.data)
     {
         cout << "Image not found" << endl;
         return -1;
     }
 
-    Mat im2;
+    cv::Mat im2;
 
     // Converts colorspace from BGR to Grayscale (BGR2GRAY)
-    cvtColor(image, im2, COLOR_BGR2GRAY);
+    cv::cvtColor(image, im2, cv::COLOR_BGR2GRAY);
 
     auto x = im2.size;
 
@@ -51,9 +50,9 @@ int main()
     cout << im2.channels() << endl;
 
     // Display resultant image
-    namedWindow("Display Image");
-    imshow("Display Image", im2);
-    waitKey(0);
+    cv::namedWindow("Display Image");
+    cv::imshow("Display Image", im2);
+    cv::waitKey(0);
 
     return 0;
 }

--- a/4_cv_basics/7_opencv_overview/3_resizing/main.cpp
+++ b/4_cv_basics/7_opencv_overview/3_resizing/main.cpp
@@ -23,13 +23,12 @@ SOFTWARE.
 */
 #include <iostream>
 #include <opencv2/opencv.hpp>
-using namespace cv;
 using namespace std;
 
 int main()
 {
-    Mat image;
-    image = imread("./assets/images/gray.png");
+    cv::Mat image;
+    image = cv::imread("./assets/images/gray.png");
     if (!image.data)
     {
         cout << "Image not found" << endl;
@@ -41,18 +40,18 @@ int main()
 
     cout << "Original Image Size: " << width << "x" << height << std::endl;
 
-    Mat im2;
+    cv::Mat im2;
 
-    Size new_size;
+    cv::Size new_size;
 
     new_size.height = 200;
     new_size.width = 700;
 
     resize(image, im2, new_size);
 
-    namedWindow("Display Image");
-    imshow("Display Image", im2);
-    waitKey(0);
+    cv::namedWindow("Display Image");
+    cv::imshow("Display Image", im2);
+    cv::waitKey(0);
 
     return 0;
 }

--- a/4_cv_basics/7_opencv_overview/4_blending/main.cpp
+++ b/4_cv_basics/7_opencv_overview/4_blending/main.cpp
@@ -23,33 +23,32 @@ SOFTWARE.
 */
 #include <iostream>
 #include <opencv2/opencv.hpp>
-using namespace cv;
 using namespace std;
 
 int main()
 {
     // Reading input images (A and B)
-    Mat image1 = imread("./assets/images/dummy1.jpg");
-    Mat image2 = imread("./assets/images/purple_night.jpg");
+    cv::Mat image1 = cv::imread("./assets/images/dummy1.jpg");
+    cv::Mat image2 = cv::imread("./assets/images/purple_night.jpg");
 
-    resize(image1, image1, Size(), 0.75, 0.75);
-    resize(image2, image2, Size(), 0.75, 0.75);
-    imshow("Image1", image1);
-    imshow("Image2", image2);
+    cv::resize(image1, image1, cv::Size(), 0.75, 0.75);
+    cv::resize(image2, image2, cv::Size(), 0.75, 0.75);
+    cv::imshow("Image1", image1);
+    cv::imshow("Image2", image2);
 
-    Mat res;
+    cv::Mat res;
 
     // Defining weights for the two images
     float alpha = 0.4, beta = (1 - alpha);
 
     // Blending image1 and image2
     // res = alpha * image1 + beta * image2 + gamma(0)
-    addWeighted(image1, alpha, image2, beta, 0.0, res);
+    cv::addWeighted(image1, alpha, image2, beta, 0.0, res);
 
-    namedWindow("Display Image");
-    resize(res, res, Size(), 0.75, 0.75);
-    imshow("Display Image", res);
-    waitKey(0);
+    cv::namedWindow("Display Image");
+    cv::resize(res, res, cv::Size(), 0.75, 0.75);
+    cv::imshow("Display Image", res);
+    cv::waitKey(0);
 
     return 0;
 }

--- a/4_cv_basics/7_opencv_overview/5_masking/main.cpp
+++ b/4_cv_basics/7_opencv_overview/5_masking/main.cpp
@@ -23,64 +23,63 @@ SOFTWARE.
 */
 #include <iostream>
 #include <opencv2/opencv.hpp>
-using namespace cv;
 using namespace std;
 
 int main()
 {
     // Load two images
-    Mat img1 = imread("./assets/images/DK.jpeg");
-    Mat img2 = imread("./assets/images/bcci.png");
-    imshow("Image1", img1);
+    cv::Mat img1 = cv::imread("./assets/images/DK.jpeg");
+    cv::Mat img2 = cv::imread("./assets/images/bcci.png");
+    cv::imshow("Image1", img1);
 
     // Getting the height, width and number of channels of the image
     // Creating ROI to put the logo on top - left corner
     int rows = img2.rows, cols = img2.cols, channels = img2.channels();
 
     // Cropping the img1
-    Mat roi = img1(Rect(0, 0, rows, cols)).clone();
+    cv::Mat roi = img1(cv::Rect(0, 0, rows, cols)).clone();
 
     // Converting the image to grayscale
     // Creating a mask of logo and create its inverse mask also
-    Mat img2gray;
-    cvtColor(img2, img2gray, COLOR_BGR2GRAY);
+    cv::Mat img2gray;
+    cv::cvtColor(img2, img2gray, cv::COLOR_BGR2GRAY);
 
     // each pixel having value more than 180(threshold)will be set to white i.e max_value(255) for a mask / HIGH
     // pixel values lower than threshold are set
-    Mat mask;
-    threshold(img2gray, mask, 180, 255, THRESH_BINARY);
+    cv::Mat mask;
+    cv::threshold(img2gray, mask, 180, 255, cv::THRESH_BINARY);
 
     // inverting colors
-    Mat mask_inv;
-    bitwise_not(mask, mask_inv);
+    cv::Mat mask_inv;
+    cv::bitwise_not(mask, mask_inv);
 
     // Resizing mask
-    resize(mask, mask, roi.size());
+    cv::resize(mask, mask, roi.size());
 
     // Blacking-out the area of logo in ROI
-    Mat img1_bg;
-    bitwise_and(roi, roi, img1_bg, mask);
+    cv::Mat img1_bg;
+    cv::bitwise_and(roi, roi, img1_bg, mask);
 
     // Take only region of logo from logo image.
-    Mat img2_fg;
-    bitwise_and(img2, img2, img2_fg, mask_inv);
+    cv::Mat img2_fg;
+    cv::bitwise_and(img2, img2, img2_fg, mask_inv);
 
-    Mat img2_fg_resized;
-    resize(img2_fg, img2_fg_resized, roi.size());
+    cv::Mat img2_fg_resized;
+    cv::resize(img2_fg, img2_fg_resized, roi.size());
 
     // Put logo in ROI and modify the main image
-    Mat dst;
-    add(img1_bg, img2_fg_resized, dst);
+    cv::Mat dst;
+    cv::add(img1_bg, img2_fg_resized, dst);
 
-    dst.copyTo(img1(Rect(0, 0, rows, cols)));
+    dst.copyTo(img1(cv::Rect(0, 0, rows, cols)));
 
-    imshow("Image2", img2);
-    imshow("ROI", roi);
-    imshow("Gray", img2gray);
-    imshow("mask", mask);
-    imshow("mask_inv", mask_inv);
-    imshow("BG", img1_bg);
-    imshow("FG", img2_fg);
-    imshow("dst", img1);
-    waitKey(0);
+    cv::imshow("Image2", img2);
+    cv::imshow("ROI", roi);
+    cv::imshow("Gray", img2gray);
+    cv::imshow("mask", mask);
+    cv::imshow("mask_inv", mask_inv);
+    cv::imshow("BG", img1_bg);
+    cv::imshow("FG", img2_fg);
+    cv::imshow("dst", img1);
+    cv::waitKey(0);
 }

--- a/4_cv_basics/7_opencv_overview/6_morphology/main.cpp
+++ b/4_cv_basics/7_opencv_overview/6_morphology/main.cpp
@@ -23,65 +23,61 @@ SOFTWARE.
 */
 #include <iostream>
 #include <opencv2/opencv.hpp>
-using namespace cv;
 using namespace std;
 
 // Function for erosion
-Mat erosion(Mat input, int kernel_size)
+cv::Mat erosion(cv::Mat input, int kernel_size)
 {
-    Mat erode_output;
-    erode(input, erode_output, getStructuringElement(MORPH_RECT, Size(kernel_size, kernel_size)));
-    return erode_output;
+   cv::Mat erode_output;
+   cv::erode(input, erode_output, cv::getStructuringElement(cv::MORPH_RECT, cv::Size(kernel_size, kernel_size)));
+   return erode_output;
 }
 
 // Function for dilation
-Mat dilation(Mat input, int kernel_size)
+cv::Mat dilation(cv::Mat input, int kernel_size)
 {
-    Mat dilate_output;
-    dilate(input, dilate_output, getStructuringElement(MORPH_RECT, Size(kernel_size, kernel_size)));
-    return dilate_output;
+   cv::Mat dilate_output;
+   cv::dilate(input, dilate_output, cv::getStructuringElement(cv::MORPH_RECT, cv::Size(kernel_size, kernel_size)));
+   return dilate_output;
 }
 
 // Function for opening
-Mat open(Mat input, int kernel_size)
+cv::Mat open(cv::Mat input, int kernel_size)
 {
-    Mat open_output;
-    morphologyEx(input, open_output, MORPH_OPEN, getStructuringElement(MORPH_RECT, Size(kernel_size, kernel_size)));
-    return open_output;
+   cv::Mat open_output;
+   cv::morphologyEx(input, open_output, cv::MORPH_OPEN, cv::getStructuringElement(cv::MORPH_RECT, cv::Size(kernel_size, kernel_size)));
+   return open_output;
 }
 
 // Function for closing
-Mat close(Mat input, int kernel_size)
+cv::Mat close(cv::Mat input, int kernel_size)
 {
-    Mat close_output;
-    morphologyEx(input, close_output, MORPH_CLOSE, getStructuringElement(MORPH_RECT, Size(kernel_size, kernel_size)));
-    return close_output;
+   cv::Mat close_output;
+   cv::morphologyEx(input, close_output, cv::MORPH_CLOSE, cv::getStructuringElement(cv::MORPH_RECT, cv::Size(kernel_size, kernel_size)));
+   return close_output;
 }
 
 // Function for gradient
-Mat gradient(Mat input, int kernel_size)
+cv::Mat gradient(cv::Mat input, int kernel_size)
 {
-    Mat gradient_output;
-    morphologyEx(input, gradient_output, MORPH_GRADIENT, getStructuringElement(MORPH_RECT, Size(kernel_size, kernel_size)));
-    return gradient_output;
+   cv::Mat gradient_output;
+   cv::morphologyEx(input, gradient_output, cv::MORPH_GRADIENT, cv::getStructuringElement(cv::MORPH_RECT, cv::Size(kernel_size, kernel_size)));
+   return gradient_output;
 }
 
 int main()
 {
-    Mat image;
-    // Reading image, in grayscale colorspace
-    image = imread("./assets/images/morph.png", IMREAD_GRAYSCALE);
-
-    // Resultant morphological transformation (change function name & kernel size)
-    Mat res = erosion(image, 5);
-
-    // Displaying source image
-    namedWindow("Source");
-    imshow("Source", image);
-
-    // Displaying transformed image
-    namedWindow("Morphology");
-    imshow("Morphology", res);
-    waitKey(0);
-    return 0;
+   cv::Mat image;
+   // Reading image, in grayscale colorspace
+   image = cv::imread("./assets/images/morph.png", cv::IMREAD_GRAYSCALE);
+   // Resultant morphological transformation (change function name & kernel size)
+   cv::Mat res = erosion(image, 5);
+   // Displaying source image
+   cv::namedWindow("Source");
+   cv::imshow("Source", image);
+   // Displaying transformed image
+   cv::namedWindow("Morphology");
+   cv::imshow("Morphology", res);
+   cv::waitKey(0);
+   return 0;
 }

--- a/4_cv_basics/7_opencv_overview/7_contours/main.cpp
+++ b/4_cv_basics/7_opencv_overview/7_contours/main.cpp
@@ -25,38 +25,38 @@ SOFTWARE.
 #include <opencv2/opencv.hpp>
 
 using namespace std;
-using namespace cv;
 
 int main()
 {
-    Mat img;
-    img = imread("./assets/images/DK.jpeg");
+   cv::Mat img;
+   img = cv::imread("./assets/images/DK.jpeg");
 
-    // 1. Convert to Grayscale
-    Mat gray;
-    cvtColor(img, gray, COLOR_BGR2GRAY);
-    imshow("Gray", gray);
+   // 1. Convert to Grayscale
 
-    // 2. Apply Canny Edge detection
-    Mat edges;
-    Canny(gray, edges, 170, 250);
-    imshow("edges", edges);
+   cv::Mat gray;
+   cv::cvtColor(img, gray, cv::COLOR_BGR2GRAY);
+   cv::imshow("Gray", gray);
 
-    // 3. Find contours
-    std::vector<std::vector<Point>> contours;
-    std::vector<Vec4i> hierarchy;
-    findContours(edges, contours, hierarchy, RETR_EXTERNAL, CHAIN_APPROX_NONE);
+   // 2. Apply Canny Edge detection
 
-    imshow("Canny edges after contouring", edges);
+   cv::Mat edges;
+   cv::Canny(gray, edges, 170, 250);
+   cv::imshow("edges", edges);
 
-    // 4. Draw contours on image
-    Mat contourImg = Mat::zeros(img.size(), CV_8UC3);
-    for (size_t i = 0; i < contours.size(); i++)
-    {
-        drawContours(img, contours, i, Scalar(0, 255, 0), 2);
-    }
+   // 3. Find contours
 
-    imshow("Contours", img);
-    waitKey(0);
-    destroyAllWindows();
+   std::vector<std::vector<cv::Point>> contours;
+   std::vector<cv::Vec4i> hierarchy;
+   cv::findContours(edges, contours, hierarchy, cv::RETR_EXTERNAL, cv::CHAIN_APPROX_NONE);
+   cv::imshow("Canny edges after contouring", edges);
+   
+   // 4. Draw contours on image
+   cv::Mat contourImg = cv::Mat::zeros(img.size(), CV_8UC3);
+   for (size_t i = 0; i < contours.size(); i++)
+   {
+       cv::drawContours(img, contours, i, cv::Scalar(0, 255, 0), 2);
+   }
+   cv::imshow("Contours", img);
+   cv::waitKey(0);
+   cv::destroyAllWindows();
 }

--- a/4_cv_basics/7_opencv_overview/8_object_detection/main.cpp
+++ b/4_cv_basics/7_opencv_overview/8_object_detection/main.cpp
@@ -25,45 +25,35 @@ SOFTWARE.
 #include <opencv2/opencv.hpp>
 
 using namespace std;
-using namespace cv;
 
 int main()
 {
-    // Read image
-    Mat img = imread("./assets/images/DK.jpeg");
-    imshow("Image", img);
-
-    // Convert image to hsv
-    Mat hsv;
-    cvtColor(img, hsv, COLOR_BGR2HSV);
-    imshow("HSV", hsv);
-
-    // hsv format -> (min hue, min saturation , min value) -> (max hue, max saturation , max value)
-    // RED mask =>
-    // Mat mask1 = inRange(hsv, Scalar(0, 100, 0), Scalar(10, 255, 255));
-
-    // YELLOW mask =>
-
-    Mat mask1;
-    inRange(hsv, Scalar(15, 30, 150), Scalar(36, 255, 255), mask1);
-    imshow("mask1", mask1);
-
-    // BLUE mask =>
-    Mat mask2;
-    inRange(hsv, Scalar(33, 52, 80), Scalar(150, 200, 255), mask2);
-    imshow("mask2", mask2);
-
-    // Final mask and masked
-    Mat mask;
-    bitwise_or(mask1, mask2, mask);
-    imshow("mask", mask);
-
-    Mat target;
-    bitwise_and(img, img, target, mask);
-    imshow("target", target);
-
-    waitKey(0);
-    destroyAllWindows();
-
-    return 0;
+   // Read image
+   cv::Mat img = cv::imread("./assets/images/DK.jpeg");
+   cv::imshow("Image", img);
+   // Convert image to hsv
+   cv::Mat hsv;
+   cv::cvtColor(img, hsv, cv::COLOR_BGR2HSV);
+   cv::imshow("HSV", hsv);
+   // hsv format -> (min hue, min saturation , min value) -> (max hue, max saturation , max value)
+   // RED mask =>
+   // Mat mask1 = inRange(hsv, Scalar(0, 100, 0), Scalar(10, 255, 255));
+   // YELLOW mask =>
+   cv::Mat mask1;
+   cv::inRange(hsv, cv::Scalar(15, 30, 150), cv::Scalar(36, 255, 255), mask1);
+   cv::imshow("mask1", mask1);
+   // BLUE mask =>
+   cv::Mat mask2;
+   cv::inRange(hsv, cv::Scalar(33, 52, 80), cv::Scalar(150, 200, 255), mask2);
+   cv::imshow("mask2", mask2);
+   // Final mask and masked
+   cv::Mat mask;
+   cv::bitwise_or(mask1, mask2, mask);
+   cv::imshow("mask", mask);
+   cv::Mat target;
+   cv::bitwise_and(img, img, target, mask);
+   cv::imshow("target", target);
+   cv::waitKey(0);
+   cv::destroyAllWindows();
+   return 0;
 }

--- a/4_cv_basics/8_blob_detection/include/blob_detection.hpp
+++ b/4_cv_basics/8_blob_detection/include/blob_detection.hpp
@@ -21,16 +21,16 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
+
 #ifndef BLOB_DETECTION_HPP
 #define BLOB_DETECTION_HPP
 
 #include <opencv2/opencv.hpp>
 
 using namespace std;
-using namespace cv;
 
 double median(vector<double> vec);
 
-tuple<double, double, double> getMedianPixelValues(Mat img);
+tuple<double, double, double> getMedianPixelValues(cv::Mat img);
 
 #endif

--- a/4_cv_basics/8_blob_detection/main.cpp
+++ b/4_cv_basics/8_blob_detection/main.cpp
@@ -25,98 +25,94 @@ SOFTWARE.
 #include <opencv2/opencv.hpp>
 #include "blob_detection.hpp"
 using namespace std;
-using namespace cv;
 
 int main()
 {
-    VideoCapture video(0); // Read input video
-    int h = 0, s = 0, v = 0;
-    while (video.isOpened())
-    {
-        Mat frame;
-        video.read(frame); // Read one frame from the video
-        namedWindow("Image", WINDOW_NORMAL);
-        resizeWindow("Image", 640, 480);        
-        imshow("Image", frame);
-
-        if (waitKey(10) == 'q') //Wait for "q" key to be pressed
-        {
-            Rect bbox = selectROI("Image", frame, false, false); // Select a region of interest on the image
-            Mat hsv;
-            cvtColor(frame, hsv, COLOR_BGR2HSV); // Convert BGR color model to HSV
-            Mat obj_img = hsv(Rect(bbox.x, bbox.y, bbox.width, bbox.height));
-            tuple<double, double, double> medians = getMedianPixelValues(obj_img); // Find the median of HSV in the selected region.
-            h = get<0>(medians);
-            s = get<1>(medians);
-            v = get<2>(medians);
-            break;
-        }
-    }
-
-    while (video.isOpened())
-    {
-        Mat frame;
-        video.read(frame);
-
-        // Converting to hsv
-        Mat hsv;
-        cvtColor(frame, hsv, COLOR_BGR2HSV);
-
-
-        // Getting lower and upper bounds for h,s,v values
-        Scalar lower(h - 5, max(0, s - 50), max(0, v - 50));
-        Scalar upper(h + 5, min(s + 50, 255), min(v + 50, 255));
-
-        // Masking
-        Mat masked;
-        inRange(hsv, lower, upper, masked);
-
-        // Median Blur
-        Mat blur;
-        medianBlur(masked, blur, 5);
-
-        // Performing bitwise_and using the 'blur' mask
-        Mat blob_mask;
-        bitwise_and(frame, frame, blob_mask, blur);
-        namedWindow("blob_mask", WINDOW_NORMAL);
-        resizeWindow("blob_mask", 640, 480);        
-        imshow("blob_mask", blob_mask);
-
-        // Find contours
-        vector<vector<Point>> contours;
-        vector<Vec4i> hierarchy;
-        findContours(blur, contours, hierarchy, RETR_TREE, CHAIN_APPROX_SIMPLE);
-
-
-        // Find largest contour
-        int idx = 0;
-        double current_max = 0;
-        int counter = 0;
-
-        for (const auto &n : contours)
-        {
-            double area = contourArea(n);
-            if (area > current_max)
-            {
-                current_max = area;
-                idx = counter;
-            }
-            counter++;
-        }
-
-        // Draw the largest contour detected
-        drawContours(frame, contours, idx, Scalar(0, 255, 255), 2);
-        namedWindow("Output", WINDOW_NORMAL);
-        resizeWindow("Output", 640, 480);        
-        imshow("Output", frame);
-
-        if (waitKey(10) == 'x')
-        {
-            destroyAllWindows();
-            video.release();
-            break;
-        }
-    }
-
-    return 0;
+   cv::VideoCapture video(0); // Read input video
+   int h = 0, s = 0, v = 0;
+   
+   while (video.isOpened())
+   {
+       cv::Mat frame;
+       video.read(frame); // Read one frame from the video
+       cv::namedWindow("Image", cv::WINDOW_NORMAL);
+       cv::resizeWindow("Image", 640, 480);
+       cv::imshow("Image", frame);
+       
+       if (cv::waitKey(10) == 'q') //Wait for "q" key to be pressed
+       {
+           cv::Rect bbox = cv::selectROI("Image", frame, false, false); // Select a region of interest on the image
+           cv::Mat hsv;
+           cv::cvtColor(frame, hsv, cv::COLOR_BGR2HSV); // Convert BGR color model to HSV
+           cv::Mat obj_img = hsv(cv::Rect(bbox.x, bbox.y, bbox.width, bbox.height));
+           tuple<double, double, double> medians = getMedianPixelValues(obj_img); // Find the median of HSV in the selected region.
+           h = get<0>(medians);
+           s = get<1>(medians);
+           v = get<2>(medians);
+           break;
+       }
+   }
+   
+   while (video.isOpened())
+   {
+       cv::Mat frame;
+       video.read(frame);
+       
+       // Converting to hsv
+       cv::Mat hsv;
+       cv::cvtColor(frame, hsv, cv::COLOR_BGR2HSV);
+       
+       // Getting lower and upper bounds for h,s,v values
+       cv::Scalar lower(h - 5, max(0, s - 50), max(0, v - 50));
+       cv::Scalar upper(h + 5, min(s + 50, 255), min(v + 50, 255));
+       
+       // Masking
+       cv::Mat masked;
+       cv::inRange(hsv, lower, upper, masked);
+       
+       // Median Blur
+       cv::Mat blur;
+       cv::medianBlur(masked, blur, 5);
+       
+       // Performing bitwise_and using the 'blur' mask
+       cv::Mat blob_mask;
+       cv::bitwise_and(frame, frame, blob_mask, blur);
+       cv::namedWindow("blob_mask", cv::WINDOW_NORMAL);
+       cv::resizeWindow("blob_mask", 640, 480);
+       cv::imshow("blob_mask", blob_mask);
+       
+       // Find contours
+       vector<vector<cv::Point>> contours;
+       vector<cv::Vec4i> hierarchy;
+       cv::findContours(blur, contours, hierarchy, cv::RETR_TREE, cv::CHAIN_APPROX_SIMPLE);
+       
+       // Find largest contour
+       int idx = 0;
+       double current_max = 0;
+       int counter = 0;
+       for (const auto &n : contours)
+       {
+           double area = cv::contourArea(n);
+           if (area > current_max)
+           {
+               current_max = area;
+               idx = counter;
+           }
+           counter++;
+       }
+       
+       // Draw the largest contour detected
+       cv::drawContours(frame, contours, idx, cv::Scalar(0, 255, 255), 2);
+       cv::namedWindow("Output", cv::WINDOW_NORMAL);
+       cv::resizeWindow("Output", 640, 480);
+       cv::imshow("Output", frame);
+       
+       if (cv::waitKey(10) == 'x')
+       {
+           cv::destroyAllWindows();
+           video.release();
+           break;
+       }
+   }
+   return 0;
 }

--- a/4_cv_basics/8_blob_detection/src/blob_detection.cpp
+++ b/4_cv_basics/8_blob_detection/src/blob_detection.cpp
@@ -30,7 +30,6 @@ SOFTWARE.
 */
 
 using namespace std;
-using namespace cv;
 
 /*
     Function to find median of a set of pixels
@@ -84,7 +83,7 @@ double median(vector<double> vec)
     A tuple containing median values for each channel.
 */
 
-tuple<double, double, double> getMedianPixelValues(Mat img)
+tuple<double, double, double> getMedianPixelValues(cv::Mat img)
 {
     // Initialize vectors to store the pixel values of each color channel
     vector<double> hue_pixels;
@@ -97,7 +96,7 @@ tuple<double, double, double> getMedianPixelValues(Mat img)
         for (int j = 0; j < img.cols; j++)
         {
             // Access the pixel value at (i, j)
-            Vec3b pixel = img.at<Vec3b>(i, j);
+            cv::Vec3b pixel = img.at<cv::Vec3b>(i, j);
 
             // Add the pixel values to the corresponding vectors
             hue_pixels.push_back(pixel[0]);


### PR DESCRIPTION
- Removed using namespace cv; to avoid ambiguity.
- Updated code to explicitly use cv:: prefix (e.g., cv::Mat).
- Helps beginners understand C++ namespace usage and improves clarity. 








