### PR TITLE
Updated Makefile of 6_morphology

### DIFF
--- a/4_cv_basics/6_morphology/Makefile
+++ b/4_cv_basics/6_morphology/Makefile
@@ -1,25 +1,32 @@
 # Specifying which compiler to use
-CC = g++							
-
+CC = g++
+							
 # Defining the name of the object that will be created after using make
-PROJECT = morphology		
-
+PROJECT = morphology
+		
 # Here Include specifies which directories can be added in the include path of the main.cpp
 CFLAGS = -std=c++11 $(shell pkg-config --cflags opencv4) -Iinclude/		
-# What libraries to be imported here it is opencv
-LIBS = $(shell pkg-config --libs opencv4) 
-
-# Similar to how we used to link ad make object files in the terminal
-# the command make build <subfolder name> should build the executable 
+# What libraries to be imported here it is opencv 
+LIBS = $(shell pkg-config --libs opencv4)
+ 
+# Source file for morphology operations
 link = src/morphology.cpp
+
+# Similar to how we used to link and make object files in the terminal
+# The command make build SRC=<FILENAME> should build the executable in the subfolder
 .PHONY: build
 build:
+ifndef SRC
+	$(error "SRC is not set")
+endif
+ifndef link
+	$(error "link is not set")
+endif
 	@echo "Building..."
-	@$(CC) $(filter-out $@,$(MAKECMDGOALS))/main.cpp $(link) -o _$(filter-out $@,$(MAKECMDGOALS)) $(CFLAGS) $(LIBS)
-%::
-	@true
-# if folder is not set, clean all build files all subfolders
+	@$(CC) $(SRC) $(link) -o $(PROJECT) $(CFLAGS) $(LIBS)
+
+# If folder is not set, clean all build files in all subfolders
 .PHONY: clean
 clean:
 	@echo "Cleaning..."
-	@rm -rf _$(filter-out $@,$(MAKECMDGOALS))
+	@rm -rf $(PROJECT)

--- a/4_cv_basics/6_morphology/README.md
+++ b/4_cv_basics/6_morphology/README.md
@@ -158,7 +158,7 @@ apply some filtering before calculating the gradient because it is very sensitiv
 ## **Usage**:
 To compile code of given subfolder command format is
 ```
-make build <subfolder name>
+make build SRC=<subfolder>/main.cpp
 ```
 To run compiled binary command format is
 ```
@@ -172,7 +172,7 @@ make clean <subfolder name>
 
 For example if you want to compile and run code in 1_erosion then use following commands
 ```
-make build 1_erosion
+make build SRC=1_erosion/main.cpp
 
 ./_1_erosion assets/normal_image.png
 ```


### PR DESCRIPTION
Updated the Makefile in 6_morphology to follow the standard build syntax used in other subfolders. Now, it uses  make SRC=<subfolder>/main.cpp  instead of  make build <subfolder>. Tested successfully.