### PR TITLE
Updated Running instructions to reflect change in directories in 4_cv_basics/4_convolutions_filtering

### DIFF
--- a/4_cv_basics/4_convolutions_filtering/README.md
+++ b/4_cv_basics/4_convolutions_filtering/README.md
@@ -225,62 +225,62 @@ possible optimizations and are not necessarily sufficient.
 ### Without Benchmarks
 
 1. Move into the cv_basics directory from the root pixels directory by running following command :
-```
+```shell
     cd 4_cv_basics 
 ```
 2. Move into the Convolutions directory from the cv_basics directory by running following command :
-```
+```shell
     cd 4_convolutions_filtering 
 ```
 3. For building the file:-
 - If you want to build naive convolution then run
-```
-    make SRC=naive.cpp link=convolution.cpp
+```shell
+    make SRC=./naive.cpp link=./src/convolution.cpp
 ```
 
 - If you want to build convolutionUsingOpenCV then run
-```
-    make SRC=convolutionUsingOpenCV.cpp link=convolution.cpp
+```shell
+    make SRC=./convolutionUsingOpenCV.cpp
 ```
 
 - If you want to build SeparableConvolution then run
-```
-    make SRC=separableConvolutions.cpp link=convolution.cpp
+```shell
+    make SRC=./separableConvolutions.cpp link=./src/convolution.cpp
 ```
 
 4. Finally execute the binary file created by running the following command :
-```
+```shell
     ./convolution_filtering
 ```
 
 ### With Benchmarks
 
 1. Move into the cv_basics directory from the root pixels directory by running following command :
-```
+```shell
     cd 4_cv_basics 
 ```
 2. Move into the Convolutions directory directory from the cv_basics directory by running following command :
-```
+```shell
     cd 4_convolutions_filtering 
 ```
 3. For building the file:-
 - If you want to build naive convolution then run
-```
+```shell
     make SRC=./benchmarks/naive.cpp link=./src/convolution.cpp
 ```
 
 - If you want to build convolutionUsingOpenCV then run
-```
-    make SRC=./benchmarks/convolutionUsingOpenCV.cpp link=./src/convolution.cpp
+```shell
+    make SRC=./benchmarks/convolutionUsingOpenCV.cpp
 ```
 
 - If you want to build SeparableConvolution then run
-```
+```shell
     make SRC=./benchmarks/separableConvolutions.cpp link=./src/convolution.cpp
 ```
 
 4. Finally execute the binary file created by running the following command :
-```
+```shell
     ./convolution_filtering
 ```
 


### PR DESCRIPTION
Resolves Issue #135
+ Changed `make` instructions for running without benchmarks to link from 4_cv_basics/4_convolutions_filtering/src/
+ Changed `make` instructions to remove the "link" variable for the build project `convolutionUsingOpenCV` as we do not need to link any extra file. We are making use of the inbuilt OpenCV function.