### PR TITLE
Changed include directive in 4_cv_basics/5_masking

### DIFF
--- a/4_cv_basics/5_masking/main.cpp
+++ b/4_cv_basics/5_masking/main.cpp
@@ -21,7 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
-#include <opencv4/opencv2/opencv.hpp>
+#include <opencv2/opencv.hpp>
 #include <iostream>
 using namespace std;
 


### PR DESCRIPTION
# Solves issue regarding paths in `4_cv_basics/5_masking`
+ Changed the preprocessor directive for the opencv.hpp file to `#include <opencv2/opencv.hpp>.

Did so because the `pkg-config --cflags opencv4` command correctly adds `/usr/bin/include/opencv4` or `/usr/bin/opencv2` (according to OS) to the include path. This does not cause an error on Ubuntu and need not cause an error on MacOS as well. (It needs to be tested once on MacOS).

Also this makes it match the README.md which tells to change to `<opencv4/opencv2/opencv.hpp>` if `<opencv2/opencv.hpp>` fails.